### PR TITLE
Fixed a potential Race Condition

### DIFF
--- a/bbmandelbrot.go
+++ b/bbmandelbrot.go
@@ -91,15 +91,11 @@ func main() {
 		}
 	}
 
-	file, err := os.Create(fname)
+	file, err := os.OpenFile(fname, os.O_CREATE|os.O_WRONLY, 0644)
 	defer file.Close()
 
-	if err != nil || file == nil {
-		file, err = os.Open(fname)
-		defer file.Close()
-		if err != nil {
-			log.Fatalf("Error opening file: %s\n", err)
-		}
+	if err != nil {
+		log.Fatalf("Error opening file: %s\n", err)
 	}
 
 	err = png.Encode(file, img)


### PR DESCRIPTION
The access of the atomic variable `var done uint64` wasn't completely atomic.
Simplified creating and opening the output file and replaced the usage of panic in favor of log package.
Also fixed the column looping over width instead of height.

I also looked at whether `img.Set(x, y, colval)` was atomically safe and it seems fine to me. I made a version[1] that uses a channel to synchronize storing the `x, y, colval` data into the image and it runs a little bit slower, which is expected, but the status reports to the terminal about every % so it looks nice and pretty. This is probably because my VM has 2 cpus and when the accumulator go routine runs, the channel's buffer is full, it gives the update loop a chance to run as well.

[1] https://github.com/ghthor/bbmandelbrot.go/tree/sync-img
